### PR TITLE
Support for truncated links in messages

### DIFF
--- a/djangotribune/parser.py
+++ b/djangotribune/parser.py
@@ -5,8 +5,9 @@ Message parser
 import re
 from datetime import datetime
 from StringIO import StringIO
+from django.template.defaultfilters import truncatechars
 
-from djangotribune.settings_local import TRIBUNE_SMILEYS_URL
+from djangotribune.settings_local import TRIBUNE_SMILEYS_URL, TRIBUNE_SHOW_TRUNCATED_URL
 
 POST_CLEANER_TAG_RE = '<(?P<tag>/?(?:b|i|s|u|tt|m|code))>'
 POST_CLEANER_SCHEME_RE = '(?P<scheme>(?:http|ftp|https|chrome|gopher|git|git+ssh|svn|svn+ssh)://)'
@@ -230,10 +231,16 @@ class PostCleaner(GenericPostCleaner):
         self.append('</clock>')
         self.matched_clocks.append(time + sel)
 
+    def truncate_link(self, scheme, url):
+        return truncatechars(url.replace(scheme + '://', ''), 100)
+
     def link_formatter(self, scheme, url):
         """
         Parse l'url pour en déterminer le titre
         """
+        if TRIBUNE_SHOW_TRUNCATED_URL:
+            return self.truncate_link(scheme, url)
+
         # Label par défaut des urls
         title = scheme
         if title == 'http':

--- a/djangotribune/settings_local.py
+++ b/djangotribune/settings_local.py
@@ -105,3 +105,5 @@ TRIBUNE_TITLES = getattr(settings, 'TRIBUNE_TITLES_AVAILABLE', (
 TRIBUNE_LASTFM_API_URL = getattr(settings, 'TRIBUNE_LASTFM_API_URL', 'http://ws.audioscrobbler.com/2.0/')
 # API Key used by djangotribune with the LastFM API
 TRIBUNE_LASTFM_API_KEY = getattr(settings, 'TRIBUNE_LASTFM_API_KEY', '07f44b8af0c8fbf981b064ff04b3bce5')
+
+TRIBUNE_SHOW_TRUNCATED_URL = getattr(settings, 'TRIBUNE_SHOW_TRUNCATED_URL', False)

--- a/djangotribune/tests.py
+++ b/djangotribune/tests.py
@@ -5,6 +5,7 @@ from django.test import TestCase
 from django.contrib.auth.models import User
 
 from djangotribune.models import Message
+from djangotribune.parser import PostCleaner
 
 class MessagesAPITest(TestCase):
     """Test the queryset API to fetch messages"""
@@ -38,3 +39,12 @@ class MessagesAPITest(TestCase):
 
     def tearDown(self):
         pass
+
+
+class ParserTest(TestCase):
+
+    def test_show_truncated_url(self):
+        link = 'http://example.com/' + 200*'a' + '/b/'
+        pc = PostCleaner(link)
+        truncated = pc.truncate_link('http', link)
+        self.assertEqual(truncated, 'example.com/' + 85*'a' + '...')


### PR DESCRIPTION
Showing truncated links in messages. Disabled by default.
